### PR TITLE
Make S3_ENABLED false as default

### DIFF
--- a/app.json
+++ b/app.json
@@ -37,7 +37,7 @@
     },
     "S3_ENABLED": {
       "description": "Should Mastodon use Amazon S3 for storage? This is highly recommended, as Heroku does not have persistent file storage (files will be lost).",
-      "value": "true",
+      "value": "false",
       "required": false
     },
     "S3_BUCKET": {


### PR DESCRIPTION
This change makes it easier to handle Review Apps while requiring
an edit on S3_ENABLED when the app is being deployed through
Heroku Button.

When a Review App is created on Heroku, config vars are taken
from app.json. With S3_ENABLED defaulting to true, the Review app
can not be built because other S3 config vars unset would make
asset compliation fail.