### PR TITLE
Build with Heroku-18 stack

### DIFF
--- a/Aptfile
+++ b/Aptfile
@@ -5,7 +5,6 @@ libidn11
 libidn11-dev
 libpq-dev
 libprotobuf-dev
-libssl-dev
 libxdamage1
 libxfixes3
 protobuf-compiler
@@ -26,4 +25,3 @@ libxcb-render0
 libthai0
 libthai-data
 libdatrie1
-zlib1g-dev

--- a/app.json
+++ b/app.json
@@ -113,5 +113,6 @@
   "addons": [
     "heroku-postgresql",
     "heroku-redis"
-  ]
+  ],
+  "stack": "heroku-18"
 }


### PR DESCRIPTION
- Set Heroku stack in app.json
- Revert #7466 removing libssl-dev and zlib1g-dev:
  libssl-dev is known to crash Puma when built on Heroku-18 stack