### PR TITLE
Stop installing libssl-dev

### DIFF
--- a/Aptfile
+++ b/Aptfile
@@ -5,7 +5,6 @@ libidn11
 libidn11-dev
 libpq-dev
 libprotobuf-dev
-libssl-dev
 libxdamage1
 libxfixes3
 protobuf-compiler


### PR DESCRIPTION
libssl-dev is provided with the build stack image and might be
conflicting in building openssl Gem for webauthn.